### PR TITLE
Adds github-commits-000.tar.gz with 3M rows for CubeStore benchmarking.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+github-commits-000.csv.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/dataset.json
+++ b/dataset.json
@@ -9,7 +9,8 @@
     {
         "name": "large",
         "files": [
-            "github-events-2015-01-01.tar.gz"
+            "github-events-2015-01-01.tar.gz",
+            "github-commits-000.tar.gz"
         ]
     }
 ]

--- a/github-commits-000.tar.gz
+++ b/github-commits-000.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76855db3989c739010084e71f6486f2adb5c4f4e199d100c9e6d8fe37254c55d
+size 79526824


### PR DESCRIPTION
* Adds github-commits-000.tar.gz with 3M rows for CubeStore benchmarking.
* Enables git-lfs to manage the bytes, see https://git-lfs.github.com