### PR TITLE
Updates github-commits to proper dataset tar format

### DIFF
--- a/github-commits-000.tar.gz
+++ b/github-commits-000.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76855db3989c739010084e71f6486f2adb5c4f4e199d100c9e6d8fe37254c55d
-size 79526824


### PR DESCRIPTION
Updates github-commits to proper dataset tar format:

```
% tar -tvf github-commits.tar.gz
drwxr-xr-x  0 cristipp staff       0 Apr  5 18:52 github-commits/
-rw-r--r--  0 cristipp staff 235332724 Mar 31 14:17 github-commits/github-commits-000.csv
```